### PR TITLE
   Fix compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     command: >
       bash -c "
       (
-        sleep 3 &&
+        mongostat -n=1  &&
         mongo --eval \"rs.initiate({'_id':'opensilex','members':[{'_id':0,'host':'opensilex-docker-mongodb:27017'}]})\" &&
         wait
       ) & docker-entrypoint.sh --replSet opensilex
@@ -77,6 +77,7 @@ services:
       - "$OPENSILEX_LOCAL_FILE_SYSTEM_DIRECTORY:$INTERNAL_DATA_DIRECTORY"
     command: >
       bash -c "
+        sudo chown -R opensilex:opensilex /home/opensilex/config &&
         rm -f /home/opensilex/config/opensilex.yml &&
         rm -f /home/opensilex/config/opensilex-template-custom.yml &&
         cat  /home/opensilex/config/opensilex-template.yml >> /home/opensilex/config/opensilex-template-custom.yml &&


### PR DESCRIPTION
    - For mongo service, change the "sleep 3" instruction into "mongostat -n 1".
    The instruction meant to wait for the server startup procedure.
    Mongostat should print up when such procedure are completed meanwhile "sleep"
    is infrastucture dependent
    - For opensilex service, reply the "chown" command at the entry point time.
    The mounted volume remaind owned by root:root otherwise and the config file
    could not be generated.